### PR TITLE
Fix ignored thesis font

### DIFF
--- a/tesi.tex
+++ b/tesi.tex
@@ -1,5 +1,5 @@
 %CLASSE DOCUMENTO - LINGUA E DIMENSIONE FONT
-\documentclass[11pt,numerazioneromana]{toptesi}
+\documentclass[corpo=11pt,numerazioneromana]{toptesi}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -1,6 +1,6 @@
 
 %CLASSE DOCUMENTO - LINGUA E DIMENSIONE FONT
-\documentclass[11pt,english,numerazioneromana]{toptesi}
+\documentclass[corpo=11pt,english,numerazioneromana]{toptesi}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
Thesis font attribute is currently ignored when building the template.
Adding `corpo` attribute from `toptesi` makes it editable.